### PR TITLE
Reduce visibility of GraalVM features

### DIFF
--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/ProtobufMessageFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/ProtobufMessageFeature.java
@@ -32,7 +32,7 @@ import org.graalvm.nativeimage.hosted.RuntimeReflection;
  * "--feature com.google.cloud.nativeimage.features.ProtobufMessageFeature"
  * to your GraalVM configuration.
  */
-public class ProtobufMessageFeature implements Feature {
+final class ProtobufMessageFeature implements Feature {
 
   // Proto classes to check on the classpath.
   private static final String PROTO_MESSAGE_CLASS = "com.google.protobuf.GeneratedMessageV3";

--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/SpannerFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/SpannerFeature.java
@@ -25,7 +25,7 @@ import org.graalvm.nativeimage.hosted.Feature;
  * Registers Spanner library classes for reflection.
  */
 @AutomaticFeature
-public class SpannerFeature implements Feature {
+final class SpannerFeature implements Feature {
 
   private static final String SPANNER_CLASS = "com.google.spanner.v1.SpannerGrpc";
 

--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/cloudfunctions/CloudFunctionsFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/cloudfunctions/CloudFunctionsFeature.java
@@ -41,7 +41,7 @@ import org.graalvm.nativeimage.hosted.RuntimeReflection;
  * A feature which registers reflective usages of the Cloud Functions library.
  */
 @AutomaticFeature
-public class CloudFunctionsFeature implements Feature {
+final class CloudFunctionsFeature implements Feature {
 
   private static final String FUNCTION_INVOKER_CLASS =
       "com.google.cloud.functions.invoker.runner.Invoker";

--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/core/GoogleJsonClientFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/core/GoogleJsonClientFeature.java
@@ -27,7 +27,7 @@ import org.graalvm.nativeimage.hosted.Feature;
  * Configures Native Image settings for the Google JSON Client.
  */
 @AutomaticFeature
-public class GoogleJsonClientFeature implements Feature {
+final class GoogleJsonClientFeature implements Feature {
 
   private static final String GOOGLE_API_CLIENT_CLASS =
       "com.google.api.client.googleapis.services.json.AbstractGoogleJsonClient";

--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/core/GrpcNettyFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/core/GrpcNettyFeature.java
@@ -28,7 +28,7 @@ import org.graalvm.nativeimage.hosted.Feature;
  * Configures Native Image settings for the grpc-netty-shaded dependency.
  */
 @AutomaticFeature
-public class GrpcNettyFeature implements Feature {
+final class GrpcNettyFeature implements Feature {
 
   private static final String GRPC_NETTY_SHADED_CLASS =
       "io.grpc.netty.shaded.io.grpc.netty.NettyServer";

--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/core/OpenCensusFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/core/OpenCensusFeature.java
@@ -25,7 +25,7 @@ import org.graalvm.nativeimage.hosted.Feature;
  * Registers reflection usage in OpenCensus libraries.
  */
 @AutomaticFeature
-public class OpenCensusFeature implements Feature {
+final class OpenCensusFeature implements Feature {
 
   private static final String OPEN_CENSUS_CLASS = "io.opencensus.impl.tags.TagsComponentImpl";
 

--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/gcp/CloudSqlFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/gcp/CloudSqlFeature.java
@@ -28,7 +28,7 @@ import org.graalvm.nativeimage.hosted.RuntimeReflection;
  * Registers GraalVM configuration for the Cloud SQL libraries.
  */
 @AutomaticFeature
-public class CloudSqlFeature implements Feature {
+final class CloudSqlFeature implements Feature {
 
   private static final String CLOUD_SQL_SOCKET_CLASS =
       "com.google.cloud.sql.core.CoreSocketFactory";


### PR DESCRIPTION
Make the GraalVM features have package-private visibility;. These classes are never meant to be used in code; avoid exposure on classpath and IDE autocomplete.