### PR TITLE
Trying GraalVM 21.3.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Set up GraalVM Compiler
       uses: DeLaGuardo/setup-graalvm@4.0
       with:
-        graalvm: '21.2.0'
+        graalvm: '21.3.0'
         java: 'java11'
         arch: 'amd64'
 


### PR DESCRIPTION
GraalVM 21.3 was released on Oct 19th. Let's see whether this causes any build failure.
https://www.graalvm.org/release-notes/21_3/