### PR TITLE
Pin setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Setup gcloud
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         version: latest
         project_id: spring-cloud-gcp-ci
@@ -68,7 +68,7 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Setup gcloud
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         version: latest
         project_id: spring-cloud-gcp-ci


### PR DESCRIPTION
`setup-gcloud` will be updating the branch name from master to main On 2022-04-05. This PR updates your GitHub Actions workflows to pin to v0 as recommended best practice [here](https://github.com/google-github-actions/setup-gcloud).

This change is already breaking our [CI runs](https://github.com/GoogleCloudPlatform/native-image-support-java/runs/5647662850).