### PR TITLE
Revert checkstyle to 9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.2</version>
+            <version>9.3</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
Because this repo's minumum Java version is still 8.