### PR TITLE
remove obsolete configurations to address GraalVM 22.1.0 breakage

### DIFF
--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/core/GrpcNettyFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/core/GrpcNettyFeature.java
@@ -124,9 +124,5 @@ final class GrpcNettyFeature implements Feature {
 
     registerForUnsafeFieldAccess(
         access, "javax.net.ssl.SSLContext", "contextSpi");
-    registerClassForReflection(
-        access, "java.lang.management.ManagementFactory");
-    registerClassForReflection(
-        access, "java.lang.management.RuntimeMXBean");
   }
 }


### PR DESCRIPTION
Fixes #393 

Reproducer of issue: https://github.com/suztomo/pubsub-sample-graal22.1-failure/pull/1.

The registration of `java.lang.management.ManagementFactory` was the root cause of the following problem in Pub/Sub and other libraries:

```
Fatal error: org.graalvm.compiler.debug.GraalError: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected a PlatformManagedObject (a MXBean defined by the virtual machine) in the image heap. This bean is introspecting the VM that runs the image builder, i.e., a VM instance that is no longer available at image runtime. Class of disallowed object: com.sun.management.internal.HotSpotDiagnostic  To see how this object got instantiated use --trace-object-instantiation=com.sun.management.internal.HotSpotDiagnostic. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
	at com.oracle.graal.pointsto.util.AnalysisFuture.setException(AnalysisFuture.java:49)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:269)
	at com.oracle.graal.pointsto.util.AnalysisFuture.ensureDone(AnalysisFuture.java:63)
	at com.oracle.graal.pointsto.heap.ImageHeapScanner.lambda$postTask$9(ImageHeapScanner.java:611)
	at com.oracle.graal.pointsto.util.CompletionExecutor.executeCommand(CompletionExecutor.java:193)
	at com.oracle.graal.pointsto.util.CompletionExecutor.lambda$executeService$0(CompletionExecutor.java:177)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected a PlatformManagedObject (a MXBean defined by the virtual machine) in the image heap. This bean is introspecting the VM that runs the image builder, i.e., a VM instance that is no longer available at image runtime. Class of disallowed object: com.sun.management.internal.HotSpotDiagnostic  To see how this object got instantiated use --trace-object-instantiation=com.sun.management.internal.HotSpotDiagnostic. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
	at com.oracle.svm.hosted.image.DisallowedImageHeapObjectFeature.error(DisallowedImageHeapObjectFeature.java:173)
	at com.oracle.svm.hosted.image.DisallowedImageHeapObjectFeature.checkDisallowedMBeanObjects(DisallowedImageHeapObjectFeature.java:162)
	at com.oracle.svm.hosted.image.DisallowedImageHeapObjectFeature.replacer(DisallowedImageHeapObjectFeature.java:119)
	at com.oracle.graal.pointsto.meta.AnalysisUniverse.replaceObject(AnalysisUniverse.java:582)
	at com.oracle.svm.hosted.ameta.AnalysisConstantReflectionProvider.replaceObject(AnalysisConstantReflectionProvider.java:257)
	at com.oracle.svm.hosted.ameta.AnalysisConstantReflectionProvider.interceptValue(AnalysisConstantReflectionProvider.java:228)
	at com.oracle.svm.hosted.heap.SVMImageHeapScanner.transformFieldValue(SVMImageHeapScanner.java:126)
	at com.oracle.graal.pointsto.heap.ImageHeapScanner.onFieldValueReachable(ImageHeapScanner.java:331)
	at com.oracle.graal.pointsto.heap.ImageHeapScanner.onFieldValueReachable(ImageHeapScanner.java:310)
	at com.oracle.graal.pointsto.heap.ImageHeapScanner.lambda$computeTypeData$1(ImageHeapScanner.java:153)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	... 10 more
```
The configuration appears to have been added in an initial commit to support grpc-netty-shaded but no longer seems necessary. 