### PR TITLE
[WIP] remove use of substitution by initializing logger classes at run-time

### DIFF
--- a/.cloudbuild/graal-build.yaml
+++ b/.cloudbuild/graal-build.yaml
@@ -12,7 +12,7 @@ steps:
         fi
 
   # Build the sample images
-  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-22.1.0
+  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.2
     entrypoint: bash
     args: ['./.cloudbuild/graal-build-script.sh']
 
@@ -48,26 +48,26 @@ steps:
     waitFor: [spanner-emulator, firestore-emulator, datastore-emulator, bigtable-emulator]
 
   # Run the tests
-  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-22.1.0
+  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.2
     args: [ './native-image-samples/native-image-samples-client-library/bigquery-sample/target/bigquery-sample' ]
 
-  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-22.1.0
+  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.2
     args: [
         './native-image-samples/native-image-samples-client-library/cloud-sql-sample/target/cloud-sql-sample',
         '-Dinstance=cloud-graalvm-support-ci:us-east1:test-instance',
         '-Dpassword=root'
     ]
 
-  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-22.1.0
+  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.2
     args: [
         './native-image-samples/native-image-samples-client-library/cloud-sql-postgres-sample/target/cloud-sql-postgres-sample',
         '-Dinstance=cloud-graalvm-support-ci:us-central1:test-postgres',
     ]
 
-  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-22.1.0
+  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.2
     args: [ './native-image-samples/native-image-samples-client-library/pubsub-sample/target/pubsub-sample' ]
 
-  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-22.1.0
+  - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.2
     args: [ './native-image-samples/native-image-samples-client-library/storage-sample/target/storage-sample' ]
 
   - name: ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Set up GraalVM Compiler
       uses: DeLaGuardo/setup-graalvm@4.0
       with:
-        graalvm: '22.1.0'
+        graalvm: '21.3.0'
         java: 'java11'
         arch: 'amd64'
 

--- a/native-image-samples/native-image-samples-quarkus/quarkus-pubsub-sample/pom.xml
+++ b/native-image-samples/native-image-samples-quarkus/quarkus-pubsub-sample/pom.xml
@@ -113,7 +113,7 @@
       <properties>
         <quarkus.package.type>native</quarkus.package.type>
         <!-- We initialize PubSubUtils at runtime since the PROJECT_ID is statically initialized there. -->
-        <quarkus.native.additional-build-args>--initialize-at-run-time=com.example.PubSubUtils\,io.grpc.netty.shaded.io.netty.util.internal.logging.Slf4JLoggerFactory\,io.grpc.netty.shaded.io.netty.util.internal.logging.Log4JLogger</quarkus.native.additional-build-args>
+        <quarkus.native.additional-build-args>--initialize-at-run-time=com.example.PubSubUtils</quarkus.native.additional-build-args>
       </properties>
     </profile>
   </profiles>

--- a/native-image-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/native-image.properties
+++ b/native-image-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/native-image.properties
@@ -13,8 +13,6 @@ Args = --allow-incomplete-classpath \
     io.grpc.netty.shaded.io.netty.channel.epoll,\
     io.grpc.netty.shaded.io.netty.channel.unix,\
     io.grpc.netty.shaded.io.netty.handler.ssl,\
-  io.grpc.netty.shaded.io.netty.util.internal.logging.Slf4JLoggerFactory,\
-  io.grpc.netty.shaded.io.netty.util.internal.logging.Log4JLogger,\
     io.grpc.internal.RetriableStream,\
     com.google.api.client.googleapis.services.AbstractGoogleClientRequest$ApiClientVersion,\
     com.google.cloud.firestore.FirestoreImpl


### PR DESCRIPTION
This should help address the following problem with upgrading to lbraries-bom 25.2.0 and later:

```
Error: Substition: io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory.newDefaultFactory(String) conflicts with previously registered: io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory.newDefaultFactory(String)
com.oracle.svm.core.util.UserError$UserException: Substition: io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory.newDefaultFactory(String) conflicts with previously registered: io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory.newDefaultFactory(String)
       at com.oracle.svm.core.util.UserError.abort(UserError.java:73)
       at com.oracle.svm.core.util.UserError.guarantee(UserError.java:101)
```

This is also to reduce a need to depend on SVM. For reference: https://github.com/googleapis/gax-java/pull/1677, 